### PR TITLE
match up source directory names

### DIFF
--- a/Getting-Started-with-Fable-and-Webpack.html
+++ b/Getting-Started-with-Fable-and-Webpack.html
@@ -160,7 +160,7 @@ npm install --save fable-core
 
 <h3>Creating F# script and HTML file</h3>
 
-<p>Fable supports both <code>fsproj</code> and plain <code>fsx</code> files. For simplicity in this example let’s use <code>fsx</code> file. Create <code>source\code.fsx</code> with follwing content:</p>
+<p>Fable supports both <code>fsproj</code> and plain <code>fsx</code> files. For simplicity in this example let’s use <code>fsx</code> file. Create <code>src\code.fsx</code> with follwing content:</p>
 
 <pre><code class="language-fsharp">#r "../node_modules/fable-core/Fable.Core.dll"
 


### PR DESCRIPTION
file creation puts the code.fsx in the source directory. Later it is referenced as src/code.fsx
src seems to be the idiomatic option